### PR TITLE
Ce/more dims

### DIFF
--- a/dags/dim.py
+++ b/dags/dim.py
@@ -60,7 +60,7 @@ def fact_subdag(parent_dag, child_dag, default_args, schedule_interval):
     return linear_subdag(parent_dag, child_dag, default_args, schedule_interval, 'fact')
 
 
-def multi_subdag(parent_dag, child_dag, default_args, schedule_interval, dim_dependencies, final_dims):
+def multi_subdag(parent_dag, child_dag, default_args, schedule_interval, dim_dependencies, final_dims, final_type):
 
     start_id = 'start_{}_batch'.format(child_dag)
     batch_slug = '{}_batch'.format(child_dag)
@@ -81,7 +81,7 @@ def multi_subdag(parent_dag, child_dag, default_args, schedule_interval, dim_dep
 
     dims = []
     for dim in dim_dependencies:
-        dep_dim_slug = '{}_dim'.format(dim)
+        dep_dim_slug = '{}_{}'.format(dim, final_type)
         dep_staging_slug = '{}_staging'.format(dim)
 
         update_staging = BashOperator(
@@ -93,7 +93,7 @@ def multi_subdag(parent_dag, child_dag, default_args, schedule_interval, dim_dep
         update_staging.set_upstream(start_batch)
 
         update_dim = BashOperator(
-            task_id='load_{}_dim'.format(dim),
+            task_id='load_{}_{}'.format(dim, final_type),
             bash_command=commit_table_template,
             params={'table_slug': dep_dim_slug, 'start_id': start_id},
             dag=dag
@@ -103,9 +103,9 @@ def multi_subdag(parent_dag, child_dag, default_args, schedule_interval, dim_dep
 
     multi_dims = []
     for dim in final_dims:
-        dim_slug = '{}_dim'.format(dim)
+        dim_slug = '{}_{}'.format(dim, final_type)
         update_multi_dim = BashOperator(
-            task_id='load_{}_dim'.format(dim),
+            task_id='load_{}_{}'.format(dim, final_type),
             bash_command=commit_table_template,
             params={'table_slug': dim_slug, 'start_id': start_id},
             dag=dag

--- a/dags/warehouse.py
+++ b/dags/warehouse.py
@@ -8,7 +8,7 @@ from dim import dim_subdag, multi_subdag, fact_subdag
 
 default_args = {
     'owner': 'cchq',
-    'depends_on_past': True,
+    'depends_on_past': False,
     'start_date': datetime(2018, 1, 14),
     'email': ['devops@dimagi.com'],
     'email_on_failure': False,
@@ -25,7 +25,7 @@ DAG_ID = 'update_warehouse'
 
 dag = DAG(DAG_ID, default_args=default_args, schedule_interval='@daily')
 
-latest_only = LatestOnlyOperator(task_id='latest_only', dag=dag)
+latest_only = LatestOnlyOperator(task_id='latest_only', dag=dag, depends_on_past=True)
 
 update_app_dim = SubDagOperator(
     subdag=dim_subdag(DAG_ID, 'application', dag.default_args, dag.schedule_interval),
@@ -47,5 +47,6 @@ update_app_status = SubDagOperator(
 
 latest_only >> update_app_dim
 latest_only >> update_user_dims
+latest_only >> update_app_status
 
 update_user_dims >> update_app_status

--- a/dags/warehouse.py
+++ b/dags/warehouse.py
@@ -50,3 +50,4 @@ latest_only >> update_user_dims
 latest_only >> update_app_status
 
 update_user_dims >> update_app_status
+update_app_dim >> update_app_status

--- a/dags/warehouse.py
+++ b/dags/warehouse.py
@@ -40,7 +40,7 @@ update_user_dims = SubDagOperator(
 )
 
 update_app_status = SubDagOperator(
-    subdag=multi_subdag(DAG_ID, 'app_status', dag.default_args, dag.schedule_interval, ['form', 'synclog'], ['app_status'], 'fact'),
+    subdag=multi_subdag(DAG_ID, 'app_status', dag.default_args, dag.schedule_interval, ['form', 'synclog'], ['app_status'], 'fact', extra_staging=['app_status_form', 'app_status_synclog']),
     task_id='app_status',
     dag=dag
 )

--- a/dags/warehouse.py
+++ b/dags/warehouse.py
@@ -30,12 +30,6 @@ update_app_dim = SubDagOperator(
     dag=dag
 )
 
-update_domain_dim = SubDagOperator(
-    subdag=dim_subdag(DAG_ID, 'domain', dag.default_args, dag.schedule_interval),
-    task_id='domain',
-    dag=dag
-)
-
 update_form_fact = SubDagOperator(
     subdag=fact_subdag(DAG_ID, 'form', dag.default_args, dag.schedule_interval),
     task_id='form',
@@ -49,14 +43,10 @@ update_synclog_fact = SubDagOperator(
 )
 
 update_user_dims = SubDagOperator(
-    subdag=multi_subdag(DAG_ID, 'user', dag.default_args, dag.schedule_interval, ['group', 'user'], ['user_group']),
+    subdag=multi_subdag(DAG_ID, 'user', dag.default_args, dag.schedule_interval, ['group', 'user', 'location', 'domain'], ['user_group', 'user_location', 'domain_membership']),
     task_id='user',
     dag=dag
 )
 
 update_user_dims >> update_form_fact
-update_domain_dim >> update_form_fact
-
-
 update_user_dims >> update_synclog_fact
-update_domain_dim >> update_synclog_fact

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+urllib3[secure]
 apache-airflow[celery, postgres, rabbitmq, crypto]==1.9.0
 gunicorn==19.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-apache-airflow[celery, postgres, rabbitmq, crypto]==1.8.1
+apache-airflow[celery, postgres, rabbitmq, crypto]==1.9.0
 gunicorn==19.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-urllib3[secure]
+tornado<=5.0.0
 apache-airflow[celery, postgres, rabbitmq, crypto]==1.9.0
 gunicorn==19.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-tornado<=5.0.0
+tornado<5.0.0
 apache-airflow[celery, postgres, rabbitmq, crypto]==1.9.0
 gunicorn==19.4


### PR DESCRIPTION
@gcapalbo @sravfeyn 
We may need to change the dependency structure at some point (i think more depends on the app dim than we give it credit for), but according to our current set of models this is the full DAG for the app status fact.

Latest only means that it will skip a run if there is another scheduled run yet to happen (so if it fails and is stopped friday and fixed monday, the runs that would have been scheduled for saturday and sunday are skipped).

Full graphs below:
overall
<img width="372" alt="screen shot 2018-02-02 at 12 38 32 pm" src="https://user-images.githubusercontent.com/6844721/35720994-1ce31e34-0816-11e8-99aa-ed31eaaef38b.png">
application
<img width="736" alt="screen shot 2018-02-02 at 12 38 44 pm" src="https://user-images.githubusercontent.com/6844721/35720995-1d160600-0816-11e8-9128-0a6895c97ded.png">
user related
<img width="915" alt="screen shot 2018-02-02 at 12 38 51 pm" src="https://user-images.githubusercontent.com/6844721/35720997-1d43097a-0816-11e8-8337-b141089ab8e8.png">
app status fact
<img width="911" alt="screen shot 2018-02-02 at 12 39 04 pm" src="https://user-images.githubusercontent.com/6844721/35720998-1d6e28b2-0816-11e8-983f-1f198239f5b2.png">
