### PR TITLE
add dashboard email list to track airflow failure

### DIFF
--- a/dags/warehouse.py
+++ b/dags/warehouse.py
@@ -6,11 +6,14 @@ from airflow.operators.subdag_operator import SubDagOperator
 from airflow.operators.latest_only_operator import LatestOnlyOperator
 from dim import dim_subdag, multi_subdag, fact_subdag
 
+
+EMAIL_LIST = ['{}@{}'.format(name, 'dimagi.com') for name in ('cellowitz', 'dashboard-aggregation-script')]
+
 default_args = {
     'owner': 'cchq',
     'depends_on_past': False,
     'start_date': datetime(2018, 1, 14),
-    'email': ['{}@{}'.format(name, 'dimagi.com') for name in ('cellowitz', 'mharrison')],
+    'email': EMAIL_LIST,
     'email_on_failure': True,
     'email_on_retry': False,
     'retries': 1,


### PR DESCRIPTION
@calellowitz @snopoke 

Is there a better email list to send the alert on?

Also, this repo is just two files mainly. Why not push this into HQ (code isolation?)? 