### PR TITLE
separate child health calc from insert

### DIFF
--- a/dags/dashboard_subdags.py
+++ b/dags/dashboard_subdags.py
@@ -180,6 +180,7 @@ def monthly_subdag(parent_dag, child_dag, default_args, schedule_interval, inter
     child_health_monthly >> agg_child_health
     ccs_record_monthly >> agg_ccs_record
     agg_child_health >> agg_awc_table
+    update_child_health_monthly_table >> agg_awc_table
     agg_ccs_record >> agg_awc_table
     agg_awc_table >> ls_tasks
     ls_tasks >> agg_ls_table

--- a/dags/dashboard_subdags.py
+++ b/dags/dashboard_subdags.py
@@ -102,6 +102,13 @@ def monthly_subdag(parent_dag, child_dag, default_args, schedule_interval, inter
         dag=monthly_dag
     )
 
+    update_child_health_monthly_table = BashOperator(
+        task_id='update_child_health_monthly_table',
+        bash_command=run_query_template,
+        params={'query': 'update_child_health_monthly_table'},
+        dag=monthly_dag
+    )
+
     agg_child_health = BashOperator(
         task_id='agg_child_health',
         bash_command=run_query_template,
@@ -169,6 +176,7 @@ def monthly_subdag(parent_dag, child_dag, default_args, schedule_interval, inter
     stage_1_tasks >> ccs_record_monthly
     update_months_table >> child_health_monthly
     update_months_table >> ccs_record_monthly
+    child_health_monthly >> update_child_health_monthly_table
     child_health_monthly >> agg_child_health
     ccs_record_monthly >> agg_ccs_record
     agg_child_health >> agg_awc_table


### PR DESCRIPTION
airflow accompaniment to 
https://github.com/dimagi/commcare-hq/pull/25782

Adds a new task to do the insert into child health monthly from the temp table that can be run in parallel to agg child health