### PR TITLE
agg awc from temp child health

### DIFF
--- a/dags/dashboard_subdags.py
+++ b/dags/dashboard_subdags.py
@@ -180,7 +180,7 @@ def monthly_subdag(parent_dag, child_dag, default_args, schedule_interval, inter
     child_health_monthly >> agg_child_health
     ccs_record_monthly >> agg_ccs_record
     agg_child_health >> agg_awc_table
-    update_child_health_monthly_table >> agg_awc_table
+    child_health_monthly >> agg_awc_table
     agg_ccs_record >> agg_awc_table
     agg_awc_table >> ls_tasks
     ls_tasks >> agg_ls_table


### PR DESCRIPTION
This is the airflow part of https://github.com/dimagi/commcare-hq/pull/25843
Removes the child health monthly final insert dependency from agg awc