### PR TITLE
remove unnecessary second chm step

### DIFF
--- a/dags/dashboard_subdags.py
+++ b/dags/dashboard_subdags.py
@@ -103,13 +103,6 @@ def monthly_subdag(parent_dag, child_dag, default_args, schedule_interval, inter
         dag=monthly_dag
     )
 
-    update_child_health_monthly_table = BashOperator(
-        task_id='update_child_health_monthly_table',
-        bash_command=run_query_template,
-        params={'query': 'update_child_health_monthly_table'},
-        dag=monthly_dag
-    )
-
     agg_child_health_temp = BashOperator(
         task_id='agg_child_health_temp',
         bash_command=run_query_template,
@@ -177,7 +170,6 @@ def monthly_subdag(parent_dag, child_dag, default_args, schedule_interval, inter
     stage_1_tasks >> ccs_record_monthly
     update_months_table >> child_health_monthly
     update_months_table >> ccs_record_monthly
-    child_health_monthly >> update_child_health_monthly_table
     child_health_monthly >> agg_child_health_temp
     ccs_record_monthly >> agg_ccs_record
     agg_child_health_temp >> update_agg_child_health
@@ -208,7 +200,6 @@ def monthly_subdag(parent_dag, child_dag, default_args, schedule_interval, inter
             dag=monthly_dag
         )
         aggregate_awc_daily >> create_mbt
-        update_child_health_monthly_table >> create_mbt
         agg_ls_table >> create_mbt
 
         create_mbt >> governance_dashboard


### PR DESCRIPTION
This is the long awaited airflow PR linked to https://github.com/dimagi/commcare-hq/pull/26409

Since we no longer copy from a temp table to the real one, but instead just attach the temp table as a partition, we can remove the copy step from airflow.